### PR TITLE
Shorter DCPU16.__init__ thanks to list comprehension

### DIFF
--- a/dcpu16.py
+++ b/dcpu16.py
@@ -20,7 +20,7 @@ class DCPU16:
     
     def __init__(self, memory):
         self.memory = [Cell(memory[i]) if i < len(memory) else Cell() for i in range(0x10000)]
-        self.registers = (Cell(), Cell(), Cell(), Cell(), Cell(), Cell(), Cell(), Cell(), Cell(), Cell(), Cell())
+        self.registers = [Cell() for _ in range(11)]
         self.skip = False
     
     def SET(self, a, b):


### PR DESCRIPTION
The two-line diff says it all. As a side effect `registers` became a list. In case it matters it can be fixed by wrapping the expression with a call to `tuple`.
