### PR TITLE
Added support for audio output system of the series DCP-16f series chip

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "examples"]
+	path = examples
+	url = git@github.com:FarMcKon/DCPU-16-Examples.git

--- a/asm_dcpu16f.py
+++ b/asm_dcpu16f.py
@@ -55,7 +55,7 @@ line_regex = re.compile(r"""
             )
         )
         |(
-            (?P<nonbasic>JSR|RRROM|AUD_O|AUD_I) # non-basic instruction
+            (?P<nonbasic>JSR|RROM|AUD_O|AUD_I) # non-basic instruction
             \s+
             ( # operand
                 (?P<op3_register>A|B|C|X|Y|Z|I|J|POP|PEEK|PUSH|SP|PC|O) # register
@@ -86,7 +86,7 @@ line_regex = re.compile(r"""
 
 IDENTIFIERS = {"A": 0x0, "B": 0x1, "C": 0x2, "X": 0x3, "Y": 0x4, "Z": 0x5, "I": 0x6, "J": 0x7, "POP": 0x18, "PC": 0x1C}
 OPCODES = {"SET": 0x1, "ADD": 0x2, "SUB": 0x3, "MUL": 0x4, "DIV": 0x5, "MOD": 0x6, "SHL": 0x7, "SHR": 0x8, "AND": 0x9, "BOR": 0xA, "XOR": 0xB, "IFE": 0xC, "IFN": 0xD, "IFG": 0xE, "IFB": 0xF}
-OPCODES_ADVANCED  = {"JSR":0x1, "RROM":0x2,"AUD_O":0x3,"AUD_I":0x4}
+OPCODES_ADVANCED  = {"JSR":0x1,"RROM":0x2,"AUD_O":0x3,"AUD_I":0x4}
 
 program = []
 labels = {}
@@ -136,6 +136,8 @@ def valuesFromAdvOperands(tokenDictionary, operandsAllowed=allAdvOperands):
 		exit (-10)
 	return(b,y)
 
+
+
 if len(sys.argv) == 3:
     input_filename = sys.argv[1]
     output_filename = sys.argv[2]
@@ -149,6 +151,7 @@ def report_error(filename, lineno, error):
 for lineno, line in enumerate(open(input_filename), start=1):
     mo = line_regex.match(line)
     if mo is None:
+    	print "mo " + str(line)
         report_error(input_filename, lineno, "Syntax error")
         break
 
@@ -247,8 +250,6 @@ for lineno, line in enumerate(open(input_filename), start=1):
     elif token_dict["nonbasic"] is not None:
         o = 0x00
         a = OPCODES_ADVANCED[token_dict["nonbasic"]]
-        if token_dict["nonbasic"] == "RRROM": #Limit type
-			(b,y) = valuesFromAdvOperands(token_dict,['op3_hex_literal','op3_decimal_literal'])
         if token_dict["nonbasic"] == "AUD_I" or token_dict["nonbasic"] == "AUD_O": #Limit type
 			(b,y) = valuesFromAdvOperands(token_dict,['op3_register',])
         else:

--- a/asm_dcpu16f.py
+++ b/asm_dcpu16f.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python
+
+import re
+import sys
+
+line_regex = re.compile(r"""
+    ^
+    \s*
+    (:(?P<label>\w+))? # label
+    \s*
+    (
+        (
+            (?P<basic>SET|ADD|SUB|MUL|DIV|MOD|SHL|SHR|AND|BOR|XOR|IFE|IFN|IFG|IFB) # basic instruction
+            \s+
+            ( # operand
+                (?P<op1_register>A|B|C|X|Y|Z|I|J|POP|PEEK|PUSH|SP|PC|O) # register
+                |
+                (\[\s*(?P<op1_register_indirect>A|B|C|X|Y|Z|I|J)\s*\]) # register indirect
+                |
+                (\[\s*(0x(?P<op1_hex_indexed>[0-9A-Fa-f]{1,4}))\s*\+\s*(?P<op1_hex_indexed_index>A|B|C|X|Y|Z|I|J)\s*\]) # hex indexed
+                |
+                (\[\s*(?P<op1_decimal_indexed>\d+)\s*\+\s*(?P<op1_decimal_indexed_index>A|B|C|X|Y|Z|I|J)\s*\]) # decimal indexed
+                |
+                (\[\s*(0x(?P<op1_hex_indirect>[0-9A-Fa-f]{1,4}))\s*\]) # hex indirect
+                |
+                (\[\s*(?P<op1_decimal_indirect>\d+)\s*\]) # decimal indirect
+                |
+                (0x(?P<op1_hex_literal>[0-9A-Fa-f]{1,4})) # hex literal
+                |
+                (?P<op1_decimal_literal>\d+) # decimal literal
+                |
+                (?P<op1_label>\w+) # label+
+            )
+            \s*
+            ,
+            \s*
+            ( # operand
+                (?P<op2_register>A|B|C|X|Y|Z|I|J|POP|PEEK|PUSH|SP|PC|O) # register
+                |
+                (\[\s*(?P<op2_register_indirect>A|B|C|X|Y|Z|I|J)\s*\]) # register indirect
+                |
+                (\[\s*(0x(?P<op2_hex_indexed>[0-9A-Fa-f]{1,4}))\s*\+\s*(?P<op2_hex_indexed_index>A|B|C|X|Y|Z|I|J)\s*\]) # hex indexed
+                |
+                (\[\s*(?P<op2_decimal_indexed>\d+)\s*\+\s*(?P<op2_decimal_indexed_index>A|B|C|X|Y|Z|I|J)\s*\]) # decimal indexed
+                |
+                (\[\s*(0x(?P<op2_hex_indirect>[0-9A-Fa-f]{1,4}))\s*\]) # hex indirect
+                |
+                (\[\s*(?P<op2_decimal_indirect>\d+)\s*\]) # decimal indirect
+                |
+                (0x(?P<op2_hex_literal>[0-9A-Fa-f]{1,4})) # hex literal
+                |
+                (?P<op2_decimal_literal>\d+) # decimal literal
+                |
+                (?P<op2_label>\w+) # label+
+            )
+        )
+        |(
+            (?P<nonbasic>JSR|RRROM|AUD_O|AUD_I) # non-basic instruction
+            \s+
+            ( # operand
+                (?P<op3_register>A|B|C|X|Y|Z|I|J|POP|PEEK|PUSH|SP|PC|O) # register
+                |
+                (\[\s*(?P<op3_register_indirect>A|B|C|X|Y|Z|I|J)\s*\]) # register indirect
+                |
+                (\[\s*(0x(?P<op3_hex_indexed>[0-9A-Fa-f]{1,4}))\s*\+\s*(?P<op3_hex_indexed_index>A|B|C|X|Y|Z|I|J)\s*\]) # hex indexed
+                |
+                (\[\s*(?P<op3_decimal_indexed>\d+)\s*\+\s*(?P<op3_decimal_indexed_index>A|B|C|X|Y|Z|I|J)\s*\]) # decimal indexed
+                |
+                (\[\s*(0x(?P<op3_hex_indirect>[0-9A-Fa-f]{1,4}))\s*\]) # hex indirect
+                |
+                (\[\s*(?P<op3_decimal_indirect>\d+)\s*\]) # decimal indirect
+                |
+                (0x(?P<op3_hex_literal>[0-9A-Fa-f]{1,4})) # hex literal
+                |
+                (?P<op3_decimal_literal>\d+) # decimal literal
+                |
+                (?P<op3_label>\w+) # label+
+            )
+        )
+    )?
+    \s*
+    (?P<comment>;.*)? # comment
+    $
+    """, re.X)
+
+
+IDENTIFIERS = {"A": 0x0, "B": 0x1, "C": 0x2, "X": 0x3, "Y": 0x4, "Z": 0x5, "I": 0x6, "J": 0x7, "POP": 0x18, "PC": 0x1C}
+OPCODES = {"SET": 0x1, "ADD": 0x2, "SUB": 0x3, "MUL": 0x4, "DIV": 0x5, "MOD": 0x6, "SHL": 0x7, "SHR": 0x8, "AND": 0x9, "BOR": 0xA, "XOR": 0xB, "IFE": 0xC, "IFN": 0xD, "IFG": 0xE, "IFB": 0xF}
+OPCODES_ADVANCED  = {"JSR":0x1, "RROM":0x2,"AUD_O":0x3,"AUD_I":0x4}
+
+program = []
+labels = {}
+
+allAdvOperands = ["op3_register","op3_register_indirect","op3_hex_indexed","op3_decimal_indexed","op3_decimal_indirect",
+'op3_hex_literal','op3_decimal_literal','op3_label']
+
+
+def valuesFromAdvOperands(tokenDictionary, operandsAllowed=allAdvOperands):
+	""" reutrns a (y,b) combo from parameters passed to a operands on advanced operators."""
+	b = y = None
+	if 'op3_register' in operandsAllowed and token_dict["op3_register"] is not None:
+		b = IDENTIFIERS[tokenDictionary["op3_register"]]
+	elif 'op3_register_indirect' in operandsAllowed and tokenDictionary["op3_register_indirect"] is not None:
+		b = 0x08 + IDENTIFIERS[tokenDictionary["op3_register_indirect"]]
+	elif 'op3_hex_indexed' in operandsAllowed and tokenDictionary["op3_hex_indexed"] is not None:
+		b = 0x10 + IDENTIFIERS[tokenDictionary["op3_hex_indexed_index"]]
+		y = int(tokenDictionary["op3_hex_indexed"], 16)
+	elif 'op3_decimal_indexed' in operandsAllowed and tokenDictionary["op3_decimal_indexed"] is not None:
+		b = 0x10 + IDENTIFIERS[tokenDictionary["op3_decimal_indexed_index"]]
+		y = int(tokenDictionary["op3_decimal_indexed"], 16)
+	elif 'op3_hex_indirect' in operandsAllowed and tokenDictionary["op3_hex_indirect"] is not None:
+		y = int(tokenDictionary["op3_hex_indirect"], 16)
+		b = 0x1E
+	elif 'op3_decimal_indirect' in operandsAllowed and tokenDictionary["op3_decimal_indirect"] is not None:
+		y = int(tokenDictionary["op3_decimal_indirect"])
+		b = 0x1E
+	elif 'op3_hex_literal' in operandsAllowed and tokenDictionary["op3_hex_literal"] is not None:
+		l = int(tokenDictionary["op3_hex_literal"], 16)
+		if l < 0x20:
+			b = 0x20 + l
+		else:
+			b = 0x1F
+			y = l
+	elif 'op3_decimal_literal' in operandsAllowed and tokenDictionary["op3_decimal_literal"] is not None:
+		l = int(tokenDictionary["op3_decimal_literal"])
+		if l < 0x20:
+			b = 0x20 + l
+		else:
+			b = 0x1F
+			y = l
+	elif 'op3_label' in operandsAllowed and tokenDictionary["op3_label"] is not None:
+		b = 0x1F
+		y = tokenDictionary["op3_label"]
+	else:
+		print "failure sauce in operands:" + str(tokenDictionary)
+		exit (-10)
+	return(b,y)
+
+if len(sys.argv) == 3:
+    input_filename = sys.argv[1]
+    output_filename = sys.argv[2]
+else:
+    print "usage: ./asm.py <input.asm> <output.obj>"
+    sys.exit(1)
+
+def report_error(filename, lineno, error):
+    print >> sys.stderr, '%s:%i: %s' % (input_filename, lineno, error)
+
+for lineno, line in enumerate(open(input_filename), start=1):
+    mo = line_regex.match(line)
+    if mo is None:
+        report_error(input_filename, lineno, "Syntax error")
+        break
+
+    token_dict = mo.groupdict()
+    if token_dict is None:
+        report_error(input_filename, lineno, "Syntax error")
+        break
+    
+    if token_dict["label"]:
+        labels[token_dict["label"]] = len(program)
+    
+    if token_dict["basic"] is not None:
+        o = OPCODES[token_dict["basic"]]
+        
+        if token_dict["op1_register"] is not None:
+            a = IDENTIFIERS[token_dict["op1_register"]]
+            x = None
+        elif token_dict["op1_register_indirect"] is not None:
+            a = 0x08 + IDENTIFIERS[token_dict["op1_register_indirect"]]
+            x = None
+        elif token_dict["op1_hex_indexed"] is not None:
+            a = 0x10 + IDENTIFIERS[token_dict["op1_hex_indexed_index"]]
+            x = int(token_dict["op1_hex_indexed"], 16)
+        elif token_dict["op1_decimal_indexed"] is not None:
+            a = 0x10 + IDENTIFIERS[token_dict["op1_decimal_indexed_index"]]
+            x = int(token_dict["op1_decimal_indexed"], 16)
+        elif token_dict["op1_hex_indirect"] is not None:
+            a = 0x1E
+            x = int(token_dict["op1_hex_indirect"], 16)
+        elif token_dict["op1_decimal_indirect"] is not None:
+            a = 0x1E
+            x = int(token_dict["op1_decimal_indirect"])
+        elif token_dict["op1_hex_literal"] is not None:
+            l = int(token_dict["op1_hex_literal"], 16)
+            if l < 0x20:
+                a = 0x20 + l
+                x = None
+            else:
+                a = 0x1F
+                x = l
+        elif token_dict["op1_decimal_literal"] is not None:
+            l = int(token_dict["op1_decimal_literal"])
+            if l < 0x20:
+                a = 0x20 + l
+                x = None
+            else:
+                a = 0x1F
+                x = l
+        elif token_dict["op1_label"] is not None:
+            a = 0x1F
+            x = token_dict["op1_label"]
+        
+        if token_dict["op2_register"] is not None:
+            b = IDENTIFIERS[token_dict["op2_register"]]
+            y = None
+        elif token_dict["op2_register_indirect"] is not None:
+            b = 0x08 + IDENTIFIERS[token_dict["op2_register_indirect"]]
+            y = None
+        elif token_dict["op2_hex_indexed"] is not None:
+            b = 0x10 + IDENTIFIERS[token_dict["op2_hex_indexed_index"]]
+            y = int(token_dict["op2_hex_indexed"], 16)
+        elif token_dict["op2_decimal_indexed"] is not None:
+            b = 0x10 + IDENTIFIERS[token_dict["op2_decimal_indexed_index"]]
+            y = int(token_dict["op2_decimal_indexed"], 16)
+        elif token_dict["op2_hex_indirect"] is not None:
+            b = 0x1E
+            y = int(token_dict["op2_hex_indirect"], 16)
+        elif token_dict["op2_decimal_indirect"] is not None:
+            b = 0x1E
+            y = int(token_dict["op2_decimal_indirect"])
+        elif token_dict["op2_hex_literal"] is not None:
+            l = int(token_dict["op2_hex_literal"], 16)
+            if l < 0x20:
+                b = 0x20 + l
+                y = None
+            else:
+                b = 0x1f
+                y = l
+        elif token_dict["op2_decimal_literal"] is not None:
+            l = int(token_dict["op2_decimal_literal"])
+            if l < 0x20:
+                b = 0x20 + l
+                y = None
+            else:
+                b = 0x1F
+                y = l
+        elif token_dict["op2_label"] is not None:
+            b = 0x1F
+            y = token_dict["op2_label"]
+        
+        program.append(((b << 10) + (a << 4) + o))
+        if x is not None:
+            program.append(x)
+        if y is not None:
+            program.append(y)
+    elif token_dict["nonbasic"] is not None:
+        o = 0x00
+        a = OPCODES_ADVANCED[token_dict["nonbasic"]]
+        if token_dict["nonbasic"] == "RRROM": #Limit type
+			(b,y) = valuesFromAdvOperands(token_dict,['op3_hex_literal','op3_decimal_literal'])
+        if token_dict["nonbasic"] == "AUD_I" or token_dict["nonbasic"] == "AUD_O": #Limit type
+			(b,y) = valuesFromAdvOperands(token_dict,['op3_register',])
+        else:
+        	(b,y) = valuesFromAdvOperands(token_dict,)
+
+        program.append(((b << 10) + (a << 4) + o))
+        if x is not None:
+            program.append(x)
+        if y is not None:
+            program.append(y)
+        
+    else: # blank line or comment-only
+        pass
+
+with open(output_filename, "wb") as f:
+    for word in program:
+        if isinstance(word, str):
+            word = labels[word]
+        hi, lo = divmod(word, 0x100)
+        f.write(chr(hi))
+        f.write(chr(lo))

--- a/dcpu16f.py
+++ b/dcpu16f.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python
+
+
+import sys
+
+
+class Cell:
+	"""
+	a cell enables us to pass around a reference to a register or memory location rather than the value
+	"""
+	def __init__(self, value=0):
+		self.value = value
+
+
+# offsets into DCPU16.registers
+PC, SP, O = 8, 9, 10
+
+
+OPCODES_ADVANCED  = {"JSR":0x1, "RROM":0x2,"AUD_O":0x3,"AUD_I":0x4}
+OPCODES = {"SET": 0x1, "ADD": 0x2, "SUB": 0x3, "MUL": 0x4, "DIV": 0x5, "MOD": 0x6, "SHL": 0x7, "SHR": 0x8, "AND": 0x9, "BOR": 0xA, "XOR": 0xB, "IFE": 0xC, "IFN": 0xD, "IFG": 0xE, "IFB": 0xF}
+
+audio_stream = []
+class DCPU16:
+	
+	def __init__(self, memory):
+		self.memory = [Cell(memory[i]) if i < len(memory) else Cell() for i in range(0x10000)]
+		self.rom = [Cell(memory[i]) if i < len(memory) else Cell() for i in range(0x32)]
+		self.rom[32] = 0x42	 #Vendor id for the series f knock-off chip
+		self.registers = tuple(Cell() for _ in range(11))
+		self.io =[Cell(),Cell()]
+		self.skip = False
+		self.tick = 0
+		audio_stream.append((self.tick,0x00))
+	def SET(self, a, b):
+		a.value = b.value
+		self.tick = self.tick +1 
+
+	def ADD(self, a, b):
+		o, r = divmod(a.value + b.value, 0x10000)
+		self.registers[O].value = o
+		a.value = r
+		self.tick = self.tick +2 
+
+	def SUB(self, a, b):
+		o, r = divmod(a.value - b.value, 0x10000)
+		self.registers[O].value = 0xFFFF if o == -1 else 0x0000
+		a.value = r
+		self.tick = self.tick +2 
+	
+	def MUL(self, a, b):
+		o, r = divmod(a.value * b.value, 0x10000)
+		a.value = r
+		self.registers[O].value = o % 0x10000
+		self.tick = self.tick +2 
+	
+	def DIV(self, a, b):
+		if b.value == 0x0:
+			r = 0x0
+			o = 0x0
+		else:
+			r = a.value / b.value % 0x10000
+			o = ((a.value << 16) / b.value) % 0x10000
+		a.value = r
+		self.registers[O].value = o
+		self.tick = self.tick +3
+
+	def MOD(self, a, b):
+		if b.value == 0x0:
+			r = 0x0
+		else:
+			r = a.value % b.value
+		a.value = r
+		self.tick = self.tick +3
+	
+	def SHL(self, a, b):
+		r = a.value << b.value
+		o = ((a.value << b.value) >> 16) % 0x10000
+		a.value = r
+		self.registers[O].value = o
+		self.tick = self.tick +2 
+	
+	def SHR(self, a, b):
+		r = a.value >> b.value
+		o = ((a.value << 16) >> b.value) % 0x10000
+		a.value = r
+		self.registers[O].value = o
+		self.tick = self.tick +2 
+	
+	def AND(self, a, b):
+		a.value = a.value & b.value
+		self.tick = self.tick +1 
+  
+	def BOR(self, a, b):
+		a.value = a.value | b.value
+		self.tick = self.tick +1 
+	
+	def XOR(self, a, b):
+		a.value = a.value ^ b.value
+		self.tick = self.tick +1 
+	
+	def IFE(self, a, b):
+		self.skip = not (a.value == b.value)
+		self.tick = self.tick +2 
+		if self.skip == False:
+			self.tick = self.tick +1 
+
+	def IFN(self, a, b):
+		self.skip = not (a.value != b.value)
+		self.tick = self.tick +2 
+		if self.skip == False:
+			self.tick = self.tick +1 
+	
+	def IFG(self, a, b):
+		self.skip = not (a.value > b.value)
+		self.tick = self.tick +2 
+		if self.skip == False:
+			self.tick = self.tick +1 
+   
+	def IFB(self, a, b):
+		self.skip = not ((a.value & b.value) != 0)
+		self.tick = self.tick +2 
+		if self.skip == False:
+			self.tick = self.tick +1 
+	
+	def JSR(self, a, b):
+		self.registers[SP].value = (self.registers[SP].value - 1) % 0x10000
+		pc = self.registers[PC].value
+		self.memory[self.registers[SP].value].value = pc
+		self.registers[PC].value = b.value
+		self.tick = self.tick +2 
+
+	
+	def RROM(self, a, b):
+		print 'b value ' + str(b.value)
+		a.value	 = self.rom[b.value].value
+		self.tick = self.tick +2 
+		print "rrom"
+		exit(-20)
+
+	def AUD_O(self, a, b):
+		a.value = b.value #io[0] = register value 
+		self.tick = self.tick +2 
+		audio_stream.append((self.tick,a.value))
+		print "aud_o at tick " + str(self.tick)
+
+	def AUD_I(self, a, b):
+		a.value = b.value
+		self.tick = self.tick +2 
+		print "aud_i at tick " + str(self.tick)
+		exit(-20)
+		
+	def get_operand(self, a):
+		if a < 0x08:
+			arg1 = self.registers[a]
+		elif a < 0x10:
+			arg1 = self.memory[self.registers[a % 0x08].value]
+		elif a < 0x18:
+			next_word = self.memory[self.registers[PC].value].value
+			self.registers[PC].value += 1
+			#print "next word " + str(next_word)
+			#print "reg_val: " + str(self.registers[a % 0x10].value)
+			#print "reg: " + str(a % 0x10)
+			arg1 = self.memory[next_word + self.registers[a % 0x10].value]
+		elif a == 0x18:
+			arg1 = self.memory[self.registers[SP].value]
+			self.registers[SP].value = (self.registers[SP].value + 1) % 0x10000
+		elif a == 0x19:
+			arg1 = self.memory[self.registers[SP].value]
+		elif a == 0x1A:
+			self.registers[SP].value = (self.registers[SP].value - 1) % 0x10000
+			arg1 = self.memory[self.registers[SP].value]
+		elif a == 0x1B:
+			arg1 = self.registers[SP]
+		elif a == 0x1C:
+			arg1 = self.registers[PC]
+		elif a == 0x1D:
+			arg1 = self.registers[O]
+		elif a == 0x1E:
+			arg1 = self.memory[self.memory[self.registers[PC].value].value]
+			self.registers[PC].value += 1
+		elif a == 0x1F:
+			arg1 = self.memory[self.registers[PC].value]
+			self.registers[PC].value += 1
+		else:
+			arg1 = Cell(a % 0x20)
+		
+		return arg1
+
+	
+	def run(self, debug=False):
+
+		while True:
+			pc = self.registers[PC].value
+			w = self.memory[pc].value
+			self.registers[PC].value += 1
+			
+			operands, opcode = divmod(w, 16)
+			b, a = divmod(operands, 64)
+			
+			if debug:
+				print "%04X: %04X" % (pc, w)
+			
+			if opcode == 0x00:
+				if	a == OPCODES_ADVANCED["JSR"]:
+					op = self.JSR
+					arg1 = None
+				elif  a == OPCODES_ADVANCED["RROM"]:
+					op = self.RROM
+					arg1 = self.registers[6]
+					#arg2 loaded below 
+					print "blarg2"
+					exit(-2)
+				elif  a == OPCODES_ADVANCED["AUD_O"]:
+					op = self.AUD_O
+					arg1 = self.io[0]
+					#arg2 loaded below 
+					#print "blarg3"
+					#exit(-3)
+				elif  a == OPCODES_ADVANCED["AUD_I"]:
+					op = self.AUD_I
+					arg1 = self.io[1] 
+					print "blarg4"
+					exit(-4)
+				else:
+					continue
+			else:
+				op = [
+					None, self.SET, self.ADD, self.SUB,
+					self.MUL, self.DIV, self.MOD, self.SHL,
+					self.SHR, self.AND, self.BOR, self.XOR, self.IFE, self.IFN, self.IFG, self.IFB
+				][opcode]
+				arg1 = self.get_operand(a)
+			
+			arg2 = self.get_operand(b)
+			
+			if self.skip:
+				if debug:
+					print "skipping"
+				self.skip = False
+			else:
+				op(arg1, arg2)
+				if debug:
+					self.dump_registers()
+					self.dump_stack()
+	
+	def dump_registers(self):
+		print " ".join("%s=%04X" % (["A", "B", "C", "X", "Y", "Z", "I", "J", "PC", "SP", "O"][i],
+			self.registers[i].value) for i in range(11))
+		print " ".join("%s=%04X" % (["AUDIO_OUT", "AUDIO_IN"][i],
+			self.io[i].value) for i in range(len(self.io)) )
+	
+	def dump_stack(self):
+		if self.registers[SP].value == 0x0:
+			print "[]"
+		else:
+			print "[" + " ".join("%04X" % self.memory[m].value for m in range(self.registers[SP].value, 0x10000)) + "]"
+
+
+if __name__ == "__main__":
+	if len(sys.argv) == 2:
+		program = []
+		f = open(sys.argv[1])
+		while True:
+			hi = f.read(1)
+			if not hi:
+				break
+			lo = f.read(1)
+			program.append((ord(hi) << 8) + ord(lo))
+		
+		dcpu16 = DCPU16(program)
+		dcpu16.run(debug=False)
+		print audio_stream
+	else:
+		print "usage: ./dcpu16.py <object-file>"


### PR DESCRIPTION
Added first draft of code for Apple I style audio output via 2 channel audio register, using reserved instructions.   To keep backwards compatibility, the series f assembler and emulator are built into separate python files for now.

This work also included a tick counter for timing, for audio use later. 
