### PR TITLE
Eliminated cells in favour of a list (for now)

### DIFF
--- a/dcpu16.py
+++ b/dcpu16.py
@@ -4,16 +4,9 @@
 import sys
 import inspect
 
-class Cell:
-    """
-    a cell enables us to pass around a reference to a register or memory location rather than the value
-    """
-    def __init__(self, value=0):
-        self.value = value
+# offsets into DCPU16.memory corresponding to addressing mode codes
+SP, PC, O = 0x1001B, 0x1001C, 0x1001D
 
-
-# offsets into DCPU16.registers corresponding to addressing mode codes
-SP, PC, O = 0x1B, 0x1C, 0x1D
 
 def opcode(code):
     """A decorator for opcodes"""
@@ -28,10 +21,9 @@ def opcode(code):
 class DCPU16:
     
     def __init__(self, memory):
-        self.memory = [Cell(memory[i]) if i < len(memory) else Cell() for i in range(0x10000)]
-        self.registers = tuple(Cell() for _ in range(30))
+        self.memory = [memory[i] if i < len(memory) else 0 for i in range(0x1001E)]
         self.skip = False
-
+        
         self.opcodes = {}
         for name, value in inspect.getmembers(self):
             if inspect.ismethod(value) and getattr(value, "_is_opcode", False):
@@ -39,127 +31,131 @@ class DCPU16:
     
     @opcode(0x01)
     def SET(self, a, b):
-        a.value = b.value
+        self.memory[a] = b
     
     @opcode(0x02)
     def ADD(self, a, b):
-        o, r = divmod(a.value + b.value, 0x10000)
-        self.registers[O].value = o
-        a.value = r
+        o, r = divmod(self.memory[a] + b, 0x10000)
+        self.memory[O] = o
+        self.memory[a] = r
     
     @opcode(0x03)
     def SUB(self, a, b):
-        o, r = divmod(a.value - b.value, 0x10000)
-        self.registers[O].value = 0xFFFF if o == -1 else 0x0000
-        a.value = r
+        o, r = divmod(self.memory[a] - b, 0x10000)
+        self.memory[O] = 0xFFFF if o == -1 else 0x0000
+        self.memory[a] = r
     
     @opcode(0x04)
     def MUL(self, a, b):
-        o, r = divmod(a.value * b.value, 0x10000)
-        a.value = r
-        self.registers[O].value = o % 0x10000
+        o, r = divmod(self.memory[a] * b, 0x10000)
+        self.memory[a] = r
+        self.memory[O] = o % 0x10000
     
     @opcode(0x05)
     def DIV(self, a, b):
-        if b.value == 0x0:
+        if b == 0x0:
             r = 0x0
             o = 0x0
         else:
-            r = a.value / b.value % 0x10000
-            o = ((a.value << 16) / b.value) % 0x10000
-        a.value = r
-        self.registers[O].value = o
+            r = self.memory[a] / b % 0x10000
+            o = ((self.memory[a] << 16) / b) % 0x10000
+        self.memory[a] = r
+        self.memory[O] = o
     
     @opcode(0x06)
     def MOD(self, a, b):
-        if b.value == 0x0:
+        if b == 0x0:
             r = 0x0
         else:
-            r = a.value % b.value
-        a.value = r
+            r = self.memory[a] % b
+        self.memory[a] = r
     
     @opcode(0x07)
     def SHL(self, a, b):
-        r = a.value << b.value
-        o = ((a.value << b.value) >> 16) % 0x10000
-        a.value = r
-        self.registers[O].value = o
+        r = self.memory[a] << b
+        o = ((self.memory[a] << b) >> 16) % 0x10000
+        self.memory[a] = r
+        self.memory[O] = o
     
     @opcode(0x08)
     def SHR(self, a, b):
-        r = a.value >> b.value
-        o = ((a.value << 16) >> b.value) % 0x10000
-        a.value = r
-        self.registers[O].value = o
+        r = self.memory[a] >> b
+        o = ((self.memory[a] << 16) >> b) % 0x10000
+        self.memory[a] = r
+        self.memory[O] = o
     
     @opcode(0x09)
     def AND(self, a, b):
-        a.value = a.value & b.value
+        self.memory[a] = self.memory[a] & b
     
     @opcode(0x0a)
     def BOR(self, a, b):
-        a.value = a.value | b.value
+        self.memory[a] = self.memory[a] | b
     
     @opcode(0x0b)
     def XOR(self, a, b):
-        a.value = a.value ^ b.value
+        self.memory[a] = self.memory[a] ^ b
     
     @opcode(0x0c)
     def IFE(self, a, b):
-        self.skip = not (a.value == b.value)
+        self.skip = not (self.memory[a] == b)
     
     @opcode(0x0d)
     def IFN(self, a, b):
-        self.skip = not (a.value != b.value)
+        self.skip = not (self.memory[a] != b)
     
     @opcode(0x0e)
     def IFG(self, a, b):
-        self.skip = not (a.value > b.value)
+        self.skip = not (self.memory[a] > b)
     
     @opcode(0x0f)
     def IFB(self, a, b):
-        self.skip = not ((a.value & b.value) != 0)
+        self.skip = not ((self.memory[a] & b) != 0)
     
     @opcode(0x010)
     def JSR(self, a, b):
-        self.registers[SP].value = (self.registers[SP].value - 1) % 0x10000
-        pc = self.registers[PC].value
-        self.memory[self.registers[SP].value].value = pc
-        self.registers[PC].value = b.value
+        self.memory[SP] = (self.memory[SP] - 1) % 0x10000
+        pc = self.memory[PC]
+        self.memory[self.memory[SP]] = pc
+        self.memory[PC] = b
     
-    def get_operand(self, a):
+    def get_operand(self, a, dereference=False):
+        literal = False
         if a < 0x08 or 0x1B <= a <= 0x1D:
-            arg1 = self.registers[a]
+            arg1 = 0x10000 + a
         elif a < 0x10:
-            arg1 = self.memory[self.registers[a % 0x08].value]
+            arg1 = self.memory[0x10000 + (a % 0x08)]
         elif a < 0x18:
-            next_word = self.memory[self.registers[PC].value].value
-            self.registers[PC].value += 1
-            arg1 = self.memory[next_word + self.registers[a % 0x10].value]
+            next_word = self.memory[self.memory[PC]]
+            self.memory[PC] += 1
+            arg1 = next_word + self.memory[0x10000 + (a % 0x10)]
         elif a == 0x18:
-            arg1 = self.memory[self.registers[SP].value]
-            self.registers[SP].value = (self.registers[SP].value + 1) % 0x10000
+            arg1 = self.memory[SP]
+            self.memory[SP] = (self.memory[SP] + 1) % 0x10000
         elif a == 0x19:
-            arg1 = self.memory[self.registers[SP].value]
+            arg1 = self.memory[SP]
         elif a == 0x1A:
-            self.registers[SP].value = (self.registers[SP].value - 1) % 0x10000
-            arg1 = self.memory[self.registers[SP].value]
+            self.memory[SP] = (self.memory[SP] - 1) % 0x10000
+            arg1 = self.memory[SP]
         elif a == 0x1E:
-            arg1 = self.memory[self.memory[self.registers[PC].value].value]
-            self.registers[PC].value += 1
+            arg1 = self.memory[self.memory[PC]]
+            self.memory[PC] += 1
         elif a == 0x1F:
-            arg1 = self.memory[self.registers[PC].value]
-            self.registers[PC].value += 1
+            arg1 = self.memory[PC]
+            self.memory[PC] += 1
         else:
-            arg1 = Cell(a % 0x20)
+            literal = True
+            arg1 = a % 0x20
         
+        if dereference and not literal:
+            arg1 = self.memory[arg1]
         return arg1
     
     def run(self, debug=False):
         while True:
-            pc = self.registers[PC].value
-            w = self.memory[pc].value
-            self.registers[PC].value += 1
+            pc = self.memory[PC]
+            w = self.memory[pc]
+            self.memory[PC] += 1
             
             operands, opcode = divmod(w, 16)
             b, a = divmod(operands, 64)
@@ -172,9 +168,9 @@ class DCPU16:
                 opcode = (a << 4) + 0x0
             else:
                 arg1 = self.get_operand(a)
-
+            
             op = self.opcodes[opcode]
-            arg2 = self.get_operand(b)
+            arg2 = self.get_operand(b, dereference=True)
             
             if self.skip:
                 if debug:
@@ -187,14 +183,16 @@ class DCPU16:
                     self.dump_stack()
     
     def dump_registers(self):
-        print(" ".join("%s=%04X" % (["A", "B", "C", "X", "Y", "Z", "I", "J", "PC", "SP", "O"][i],
-            self.registers[i].value) for i in range(11)))
+        print(" ".join("%s=%04X" % (["A", "B", "C", "X", "Y", "Z", "I", "J"][i],
+            self.memory[0x10000 + i]) for i in range(8)))
+        print(" ".join("%s=%04X" % (["PC", "SP", "O"][i - PC],
+            self.memory[i]) for i in [PC, SP, O]))
     
     def dump_stack(self):
-        if self.registers[SP].value == 0x0:
+        if self.memory[SP] == 0x0:
             print("[]")
         else:
-            print("[" + " ".join("%04X" % self.memory[m].value for m in range(self.registers[SP].value, 0x10000)) + "]")
+            print("[" + " ".join("%04X" % self.memory[m] for m in range(self.memory[SP], 0x10000)) + "]")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Cells existed to allow the first argument of each operation to take
a reference to a register or memory location so it could be set.

This has been replaced by first observing that the first argument
to each operation is always a reference (register or memory) and never
a literal and that the second argument can always be deferences before
being passed in and so can be treated as a literal value in all cases.

The remaining trick, then, was to treat registers and memory locations
with the same addressing scheme by placing the registers in offsets
0x10000+ in the "memory" list.
