### PR TITLE
Debugger [COMPLETE]

### DIFF
--- a/dcpu16.py
+++ b/dcpu16.py
@@ -32,7 +32,7 @@ class DCPU16:
         self.skip = False
         self.cycle = 0
 
-        self.debugger_breaks = []
+        self.debugger_breaks = set()
         self.debugger_in_continue = False
         
         self.opcodes = {}
@@ -235,7 +235,13 @@ class DCPU16:
                     elif command[0] in ("set", "s"):
                         self.debugger_set(*command[1:])
                     elif command[0] in ("break", "b"):
+                        if len(command) < 2:
+                            raise ValueError("Break command takes at least 1 parameter!")
                         self.debugger_break(*command[1:])
+                    elif command[0] in ("clear", "cl"):
+                        if len(command) < 2:
+                            raise ValueError("Clear command takes at least 1 parameter!")
+                        self.debugger_clear(*command[1:])
                     elif command[0] in ("continue", "cont", "c"):
                         self.debugger_in_continue = True
                         break
@@ -263,13 +269,22 @@ class DCPU16:
             return addr
 
     def debugger_break(self, *addrs):
-        breaks = []
+        breaks = set()
         for addr in addrs:
             addr = int(addr, 16)
             if not 0 <= addr <= 0xFFFF:
                 raise ValueError("Invalid address!")
-            breaks.append(addr)
-        self.debugger_breaks += breaks
+            breaks.add(addr)
+        self.debugger_breaks.update(breaks)
+
+    def debugger_clear(self, *addrs):
+        breaks = set()
+        for addr in addrs:
+            addr = int(addr, 16)
+            if not 0 <= addr <= 0xFFFF:
+                raise ValueError("Invalid address!")
+            breaks.add(addr)
+        self.debugger_breaks.difference_update(breaks)
 
     def debugger_set(self, what, value):
         value = int(value, 16)

--- a/dcpu16.py
+++ b/dcpu16.py
@@ -226,12 +226,12 @@ class DCPU16:
                     print("")
                     sys.exit()
                 try:
-                    if not command or command[0] in ("step", "s"):
+                    if not command or command[0] in ("step", "st"):
                         break
                     elif command[0] == "help":
                         help_msg = """Commands:
 help
-s[tep] - (or simply newline) - execute next instruction
+st[ep] - (or simply newline) - execute next instruction
 g[et] <address>|%<register> - (also p[rint]) - print value of memory cell or register
 s[et] <address>|%<register> <value_in_hex> - set value of memory cell or register to <value_in_hex>
 b[reak] <address> [<address2>...] - set breakpoint at given addresses (to be used with 'continue')

--- a/dcpu16.py
+++ b/dcpu16.py
@@ -231,19 +231,34 @@ class DCPU16:
                     except ValueError as ex:
                         print(ex)
 
+    @staticmethod
+    def debugger_parse_location(what):
+        registers = "abcxyzij"
+        specials = ("pc", "sp", "o")
+        if what.startswith("%"):
+            what = what[1:]
+            if what in registers:
+                return  0x10000 + registers.find(what)
+            elif what in specials:
+                return  (PC, SP, O)[specials.index(what)]
+            else:
+                raise ValueError("Invalid register!")
+        else:
+            addr = int(what, 16)
+            if not 0 <= addr <= 0xFFFF:
+                raise ValueError("Invalid address!")
+            return addr
+
+
     def debugger_set(self, what, value):
-        addr = int(what, 16)
-        if not 0 <= addr <= 0xFFFF:
-            raise ValueError("Invalid address!")
         value = int(value, 16)
         if not 0 <= value <= 0xFFFF:
             raise ValueError("Invalid value!")
+        addr = self.debugger_parse_location(what)
         self.memory[addr] = value
 
     def debugger_get(self, what):
-        addr = int(what, 16)
-        if not 0 <= addr <= 0xFFFF:
-            raise ValueError("Invalid address!")
+        addr = self.debugger_parse_location(what)
         value = self.memory[addr]
         print("hex: {hex}\ndec: {dec}\nbin: {bin}".format(hex=hex(value), dec=value, bin=bin(value)))
     

--- a/dcpu16.py
+++ b/dcpu16.py
@@ -217,17 +217,35 @@ class DCPU16:
                         # Ctrl-D
                         print("")
                         sys.exit()
-                    if not command or command[0] in ("step", "s"):
-                        break
-                    elif command[0] in ("get", "g", "print", "p"):
-                        addr = int(command[1], 16)
-                        if not 0 <= addr <= 0xFFFF:
-                            print("Invalid address!")
-                            continue
-                        value = self.memory[addr]
-                        print("hex: {hex}\ndec: {dec}\nbin: {bin}".format(hex=hex(value), dec=value, bin=bin(value)))
-                    else:
-                        print("Invalid command!")
+                    try:
+                        if not command or command[0] in ("step", "s"):
+                            break
+                        elif command[0] == "help":
+                            print("Commands:\n\thelp\n\tstep\n\tget <addr>\n\tset <addr> <value>")
+                        elif command[0] in ("get", "g", "print", "p"):
+                            self.debugger_get(*command[1:])
+                        elif command[0] in ("set", "s"):
+                            self.debugger_set(*command[1:])
+                        else:
+                            raise ValueError("Invalid command!")
+                    except ValueError as ex:
+                        print(ex)
+
+    def debugger_set(self, what, value):
+        addr = int(what, 16)
+        if not 0 <= addr <= 0xFFFF:
+            raise ValueError("Invalid address!")
+        value = int(value, 16)
+        if not 0 <= value <= 0xFFFF:
+            raise ValueError("Invalid value!")
+        self.memory[addr] = value
+
+    def debugger_get(self, what):
+        addr = int(what, 16)
+        if not 0 <= addr <= 0xFFFF:
+            raise ValueError("Invalid address!")
+        value = self.memory[addr]
+        print("hex: {hex}\ndec: {dec}\nbin: {bin}".format(hex=hex(value), dec=value, bin=bin(value)))
     
     def dump_registers(self):
         print(" ".join("%s=%04X" % (["A", "B", "C", "X", "Y", "Z", "I", "J"][i],

--- a/dcpu16.py
+++ b/dcpu16.py
@@ -6,6 +6,11 @@ import struct
 import sys
 import argparse
 
+try:
+    raw_input
+except NameError:
+    raw_input = input
+
 # offsets into DCPU16.memory corresponding to addressing mode codes
 SP, PC, O = 0x1001B, 0x1001C, 0x1001D
 
@@ -203,6 +208,26 @@ class DCPU16:
                 if debug:
                     self.dump_registers()
                     self.dump_stack()
+
+            if debug:
+                while True:
+                    try:
+                        command = [s.lower() for s in raw_input("debug> ").split()]
+                    except EOFError:
+                        # Ctrl-D
+                        print("")
+                        sys.exit()
+                    if not command or command[0] in ("step", "s"):
+                        break
+                    elif command[0] in ("get", "g", "print", "p"):
+                        addr = int(command[1], 16)
+                        if not 0 <= addr <= 0xFFFF:
+                            print("Invalid address!")
+                            continue
+                        value = self.memory[addr]
+                        print("hex: {hex}\ndec: {dec}\nbin: {bin}".format(hex=hex(value), dec=value, bin=bin(value)))
+                    else:
+                        print("Invalid command!")
     
     def dump_registers(self):
         print(" ".join("%s=%04X" % (["A", "B", "C", "X", "Y", "Z", "I", "J"][i],

--- a/dcpu16.py
+++ b/dcpu16.py
@@ -229,7 +229,19 @@ class DCPU16:
                     if not command or command[0] in ("step", "s"):
                         break
                     elif command[0] == "help":
-                        print("Commands:\n\thelp\n\tstep\n\tget <addr>\n\tset <addr> <value>")
+                        help_msg = """Commands:
+help
+s[tep] - (or simply newline) - execute next instruction
+g[et] <address>|%<register> - (also p[rint]) - print value of memory cell or register
+s[et] <address>|%<register> <value_in_hex> - set value of memory cell or register to <value_in_hex>
+b[reak] <address> [<address2>...] - set breakpoint at given addresses (to be used with 'continue')
+cl[ear] <address> [<address2>...] - remove breakpoints from given addresses
+c[ont[inue]] - run without debugging prompt until breakpoint is encountered
+
+All addresses are in hex (you can add '0x' at the beginning)
+Close emulator with Ctrl-D
+"""
+                        print(help_msg)
                     elif command[0] in ("get", "g", "print", "p"):
                         self.debugger_get(*command[1:])
                     elif command[0] in ("set", "s"):
@@ -306,9 +318,9 @@ class DCPU16:
     
     def dump_stack(self):
         if self.memory[SP] == 0x0:
-            print("[]")
+            print("Stack: []")
         else:
-            print("[" + " ".join("%04X" % self.memory[m] for m in range(self.memory[SP], 0x10000)) + "]")
+            print("Stack: [" + " ".join("%04X" % self.memory[m] for m in range(self.memory[SP], 0x10000)) + "]")
 
 
 if __name__ == "__main__":

--- a/dcpu16.py
+++ b/dcpu16.py
@@ -216,8 +216,6 @@ class DCPU16:
                 self.debugger_prompt()
 
     def debugger_prompt(self):
-        print(self.memory[PC])
-        print(self.debugger_breaks)
         if not self.debugger_in_continue or self.memory[PC] in self.debugger_breaks:
             self.debugger_in_continue = False
             while True:
@@ -264,11 +262,14 @@ class DCPU16:
                 raise ValueError("Invalid address!")
             return addr
 
-    def debugger_break(self, addr):
-        addr = int(addr, 16)
-        if not 0 <= addr <= 0xFFFF:
-            raise ValueError("Invalid address!")
-        self.debugger_breaks.append(addr)
+    def debugger_break(self, *addrs):
+        breaks = []
+        for addr in addrs:
+            addr = int(addr, 16)
+            if not 0 <= addr <= 0xFFFF:
+                raise ValueError("Invalid address!")
+            breaks.append(addr)
+        self.debugger_breaks += breaks
 
     def debugger_set(self, what, value):
         value = int(value, 16)

--- a/dcpu16.py
+++ b/dcpu16.py
@@ -181,7 +181,7 @@ class DCPU16:
             arg1 = self.memory[arg1]
         return arg1
     
-    def run(self, debug=False):
+    def run(self, debug=False, trace=False):
         while True:
             pc = self.memory[PC]
             w = self.memory[pc]
@@ -190,7 +190,7 @@ class DCPU16:
             operands, opcode = divmod(w, 16)
             b, a = divmod(operands, 64)
             
-            if debug:
+            if trace:
                 print("(%08X) %04X: %04X" % (self.cycle, pc, w))
             
             if opcode == 0x00:
@@ -203,12 +203,12 @@ class DCPU16:
             arg2 = self.get_operand(b, dereference=True)
             
             if self.skip:
-                if debug:
+                if trace:
                     print("skipping")
                 self.skip = False
             else:
                 op(arg1, arg2)
-                if debug:
+                if trace:
                     self.dump_registers()
                     self.dump_stack()
 
@@ -325,9 +325,12 @@ Close emulator with Ctrl-D
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="DCPU-16 emulator")
-    parser.add_argument("-d", "--debug", action="store_const", const=True, default=False, help="Run emulator in debug mode")
+    parser.add_argument("-d", "--debug", action="store_const", const=True, default=False, help="Run emulator in debug mode. This implies '--trace'")
+    parser.add_argument("-t", "--trace", action="store_const", const=True, default=False, help="Print dump of registers and stack after every step")
     parser.add_argument("object_file", help="File with assembled DCPU binary")
     args = parser.parse_args()
+    if args.debug:
+        args.trace = True
     
     program = []
     with open(args.object_file, "rb") as f:
@@ -337,4 +340,4 @@ if __name__ == "__main__":
             word = f.read(2)
     
     dcpu16 = DCPU16(program)
-    dcpu16.run(debug=args.debug)
+    dcpu16.run(debug=args.debug, trace=args.trace)


### PR DESCRIPTION
--debug mode now stops after every cycle and asks command from user.
Current debugger commands:
- g[et] addr
- g[et] %register
- s[et] addr value
- s[et] %register value
- help
- st[ep]
- break addr[...]
- c[ont[inue]]
- cl[ear] addr[...]
- `Ctrl-D` - exit

get is also aliased as p[rint], step as empty string.
Detailed info - `help` command.
