### PR TITLE
Terminal related cleanups

### DIFF
--- a/dcpu16.py
+++ b/dcpu16.py
@@ -239,7 +239,10 @@ class DCPU16:
                 last_cycle = self.cycle
                 tick = 0
             if tick % 1000 == 0:
-                self.display.redraw()
+                try:
+                    self.display.redraw()
+                except SystemExit:
+                    break
             
             if debug:
                 self.display.redraw()

--- a/dcpu16.py
+++ b/dcpu16.py
@@ -380,6 +380,7 @@ if __name__ == "__main__":
     dcpu16 = DCPU16(program, display=term)
     try:
         dcpu16.run(debug=args.debug, trace=args.trace, show_speed=args.speed)
-        term.quit()
     except KeyboardInterrupt:
+        pass
+    finally:
         term.quit()

--- a/qt_terminal.py
+++ b/qt_terminal.py
@@ -31,6 +31,9 @@ class Terminal(QtGui.QWidget):
         self.setMinimumSize(self.width, self.height)
         self.setMaximumSize(self.width, self.height)
         self.setWindowTitle("DCPU-16 terminal")
+        
+        self.app.setQuitOnLastWindowClosed(False)
+        self.closed = False
     
     def update_memory(self, address, value):
         if self.START_ADDRESS <= address < (self.START_ADDRESS + self.VSIZE * self.HSIZE):
@@ -40,7 +43,12 @@ class Terminal(QtGui.QWidget):
             char = chr(value & 0x00FF)
             self.buffer[line][col] = char
     
+    def closeEvent(self, e):
+        self.closed = True
+    
     def redraw(self):
+        if self.closed:
+            raise SystemExit
         self.update()
         self.app.processEvents()
     


### PR DESCRIPTION
Shutdown the QT terminal when closed and removed a redundant term.close()
