### PR TITLE
Shutdown debugger correctly

### DIFF
--- a/plugins/debuggerplugin.py
+++ b/plugins/debuggerplugin.py
@@ -31,7 +31,7 @@ class DebuggerPlugin(BasePlugin):
                 except EOFError:
                     # Ctrl-D
                     print("")
-                    sys.exit()
+                    raise SystemExit
                 try:
                     if not command or command[0] in ("step", "st"):
                         break


### PR DESCRIPTION
Debugger was throwing an exception when closing as sys was not imported.  It throws SystemExit now in convention with the rest of the plugins.
