### PR TITLE
Added keyboard input to pygame, qt, and curses

### DIFF
--- a/terminals/curses_terminal.py
+++ b/terminals/curses_terminal.py
@@ -21,9 +21,12 @@ class Terminal:
             print("Curses conflicts with debugger")
             raise SystemExit
         self.win = curses.initscr()
+        self.win.nodelay(1)
         curses.curs_set(0)
+        curses.noecho()
         self.width = WIDTH
         self.height = HEIGHT
+        self.keys = []
         self.setup_colors()
     
     def get_color(self, fg, bg):
@@ -48,6 +51,15 @@ class Terminal:
     
     def show(self):
         pass
+    
+    def updatekeys(self):
+        try:
+            while(True):
+                char = self.win.getkey()
+                if len(char) == 1:
+                    self.keys.insert(0, ord(char))
+        except curses.error:
+            pass
     
     def redraw(self):
         self.win.refresh()

--- a/terminals/debug_terminal.py
+++ b/terminals/debug_terminal.py
@@ -4,6 +4,7 @@ HEIGHT = 16
 class Terminal:
     width = WIDTH
     height = HEIGHT
+    keys = []
     
     def __init__(self, args):
         pass
@@ -12,6 +13,9 @@ class Terminal:
         print("TERMINAL (%d,%d:'%s') %s" % (column, row, chr(character), str(color)))
     
     def show(self):
+        pass
+    
+    def updatekeys(self):
         pass
     
     def redraw(self):

--- a/terminals/pygame_terminal.py
+++ b/terminals/pygame_terminal.py
@@ -10,6 +10,7 @@ class Terminal:
     def __init__(self, args):
         self.width = WIDTH
         self.height = HEIGHT
+        self.keys = []
         pygame.font.init()
         self.font = pygame.font.match_font("Monospace,dejavusansmono")
         self.font = pygame.font.get_default_font() if not self.font else self.font
@@ -35,6 +36,13 @@ class Terminal:
     
     def show(self):
         pass
+    
+    def updatekeys(self):
+        events = pygame.event.get(pygame.KEYDOWN)
+        for e in events:
+            key = e.unicode
+            if key:
+                self.keys.insert(0, ord(e.unicode))
     
     def redraw(self):
         pygame.display.flip()

--- a/terminals/qt_terminal.py
+++ b/terminals/qt_terminal.py
@@ -9,13 +9,13 @@ signal.signal(signal.SIGINT, signal.SIG_DFL)
 class Terminal(QtGui.QWidget):
     VSIZE = 25
     HSIZE = 60
-    BUFFER_SIZE = VSIZE * HSIZE
     
     COLORS = [(0,0,0), (255,0,0), (0,255,0), (255,255,0), (0,0,255), (255,0,255), (0, 255, 255), (255, 255, 255)]
     
     def __init__(self, args):
-        self.width = self.VSIZE
-        self.height = self.HSIZE
+        self.width = self.HSIZE
+        self.height = self.VSIZE
+        self.keys = []
         self.app = QtGui.QApplication(sys.argv)
         super(Terminal, self).__init__()
         
@@ -58,6 +58,13 @@ class Terminal(QtGui.QWidget):
     
     def closeEvent(self, e):
         self.closed = True
+    
+    def keyPressEvent(self, e):
+        for c in str(e.text()):
+            self.keys.insert(0, ord(c))
+    
+    def updatekeys(self):
+        pass
     
     def redraw(self):
         if self.closed:


### PR DESCRIPTION
- Corrected qt width/height being switched
- Tested with https://gist.github.com/2340075 (Maybe one for examples?)
- Special keys such as arrow keys, return, etc act undefined (We can define once Notch or everyone else does)
- Added a MIN_DISPLAY_HZ constant to define how often (at-most) the display should update
