### PR TITLE
Fixed a terminal crash, only inform plugins of memory changes

### DIFF
--- a/dcpu16.py
+++ b/dcpu16.py
@@ -226,10 +226,15 @@ class DCPU16:
                     print("skipping")
                 self.skip = False
             else:
-                op(arg1, arg2)
                 if 0x01 <= opcode <=0xB: # write to memory
-                    for p in self.plugins:
-                        p.memory_changed(self, arg1, self.memory[arg1])
+                    oldval = self.memory[arg1]
+                    op(arg1, arg2)
+                    val = self.memory[arg1]
+                    if oldval != val:
+                        for p in self.plugins:
+                            p.memory_changed(self, arg1, val, oldval)
+                else:
+                    op(arg1, arg2)
                 if trace:
                     self.dump_registers()
                     self.dump_stack()

--- a/emuplugin.py
+++ b/emuplugin.py
@@ -43,7 +43,7 @@ class BasePlugin:
         """
         pass
     
-    def memory_changed(self, cpu, address, value):
+    def memory_changed(self, cpu, address, value, oldvalue):
         """
             Gets called on a write to memory
         """

--- a/plugins/terminalplugin.py
+++ b/plugins/terminalplugin.py
@@ -38,13 +38,14 @@ class TerminalPlugin(BasePlugin):
         if self.term.keys:
             self.processkeys(cpu)
     
-    def memory_changed(self, cpu, address, value):
+    def memory_changed(self, cpu, address, value, oldval):
         """
             Inform the terminal that the memory is updated
         """
         if START_ADDRESS <= address <= START_ADDRESS + self.term.width * self.term.height:
             row, column = divmod(address - START_ADDRESS, self.term.width)
             ch = value % 0x0080
+            ch = ord(' ') if not ch else ch
             fg = (value & 0x4000) >> 14 | (value & 0x2000) >> 12 | (value & 0x1000) >> 10
             bg = (value & 0x400) >> 10 | (value & 0x200) >> 8 | (value & 0x100) >> 6
             self.term.update_character(row, column, ch, (fg, bg))


### PR DESCRIPTION
Fixed a terminal crash, only inform plugins of memory changes
- Only inform the plugins of memory changes, not writes (Speeds up terminals a lot when clearing the screen often)
- Fixed a terminal crash with writing the 0x0 character
